### PR TITLE
Status and version

### DIFF
--- a/queenbee/job/job.py
+++ b/queenbee/job/job.py
@@ -10,6 +10,8 @@ class Job(BaseModel):
 
     A Job is an object to submit a list of arguments to execute a Queenbee recipe.
     """
+    api_version: constr(regex='^Job$') = 'Job'
+
     type: constr(regex='^Job$') = 'Job'
 
     source: str = Field(

--- a/queenbee/job/job.py
+++ b/queenbee/job/job.py
@@ -10,7 +10,7 @@ class Job(BaseModel):
 
     A Job is an object to submit a list of arguments to execute a Queenbee recipe.
     """
-    api_version: constr(regex='^Job$') = 'Job'
+    api_version: constr(regex='^v1beta1$') = 'v1beta1'
 
     type: constr(regex='^Job$') = 'Job'
 

--- a/queenbee/job/status.py
+++ b/queenbee/job/status.py
@@ -118,6 +118,8 @@ class StepStatus(BaseStatus):
 
 class JobStatus(BaseStatus):
     """Job Status."""
+    api_version: constr(regex='^v1beta1$') = 'v1beta1'
+
     type: constr(regex='^JobStatus$') = 'JobStatus'
 
     id: str = Field(

--- a/queenbee/job/status.py
+++ b/queenbee/job/status.py
@@ -132,7 +132,12 @@ class JobStatus(BaseStatus):
 
     steps: Dict[str, StepStatus] = {}
 
+    inputs: List[StepInputs] = Field(
+        ...,
+        description='The inputs used for this job.'
+    )
+
     outputs: List[StepOutputs] = Field(
         ...,
-        description='The outputs produced by this step.'
+        description='The outputs produced by this job.'
     )

--- a/queenbee/plugin/plugin.py
+++ b/queenbee/plugin/plugin.py
@@ -64,6 +64,8 @@ class Plugin(BaseModel):
     A plugin contains runtime configuration for a Command Line Interface (CLI) and
     a list of functions that can be executed using this CLI tool.
     """
+    api_version: constr(regex='^v1beta1$') = 'v1beta1'
+
     type: constr(regex='^Plugin') = 'Plugin'
 
     metadata: MetaData = Field(

--- a/queenbee/recipe/recipe.py
+++ b/queenbee/recipe/recipe.py
@@ -56,6 +56,8 @@ class TemplateFunction(Function):
 
 class Recipe(BaseModel):
     """A Queenbee Recipe"""
+    api_version: constr(regex='^v1beta1$') = 'v1beta1'
+
     type: constr(regex='^Recipe$') = 'Recipe'
 
     metadata: MetaData = Field(
@@ -688,6 +690,8 @@ class RecipeInterface(BaseModel):
     Recipe information only includes metadata, source, inputs and outputs of a Recipe.
     This object is useful for creating user interface for Recipes.
     """
+    api_version: constr(regex='^v1beta1$') = 'v1beta1'
+
     type: constr(regex='^RecipeInterface$') = 'RecipeInterface'
 
     metadata: MetaData = Field(

--- a/queenbee/repository/index.py
+++ b/queenbee/repository/index.py
@@ -43,6 +43,7 @@ class RepositoryMetadata(BaseModel):
 
 class RepositoryIndex(BaseModel):
     """A searchable index for a Queenbee Plugin and Recipe repository"""
+    api_version: constr(regex='^v1beta1$') = 'v1beta1'
 
     type: constr(regex='^RepositoryIndex$') = 'RepositoryIndex'
 


### PR DESCRIPTION
This PR addresses the JobStatus I/O types issue and proposes an api versioning scheme set on specific object.

API versioning should only be set ofData Transfer Objects (DTOs) are any object that we expect to be used to be used by an external API (ie: not-queenbee) to be parsed and computed.

I have opted for a version and maturity flag for API versions (ie: version = v1 and maturity = beta1). This versioning scheme should ideally work like described for the Kubernetes project: https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups-and-versioning

fix #209