### PR TITLE
fix(license): remove license file

### DIFF
--- a/queenbee/base/metadata.py
+++ b/queenbee/base/metadata.py
@@ -7,7 +7,7 @@ https://swagger.io/specification/#infoObject
 """
 
 from typing import List
-from pydantic import Field, constr
+from pydantic import Field, constr, AnyUrl
 
 from .basemodel import BaseModel
 
@@ -36,7 +36,7 @@ class License(BaseModel):
         description='The license name used for the package.'
     )
 
-    url: str = Field(
+    url: AnyUrl = Field(
         None,
         description='A URL to the license used for the package.'
     )

--- a/queenbee/plugin/plugin.py
+++ b/queenbee/plugin/plugin.py
@@ -1,4 +1,5 @@
 """Queenbee Plugin class."""
+import json
 import os
 import yaml
 from typing import List
@@ -143,7 +144,7 @@ class Plugin(BaseModel):
 
         return cls.parse_obj(plugin)
 
-    def to_folder(self, folder_path: str, readme_string: str = None, license_string: str = None):
+    def to_folder(self, folder_path: str, *, readme_string: str = None):
         """Write a plugin to a folder
 
         Note:
@@ -164,7 +165,6 @@ class Plugin(BaseModel):
 
         Keyword Arguments:
             readme_string {str} -- The README file string (default: {None})
-            license_string {str} -- The LICENSE file string (default: {None})
         """
         os.makedirs(os.path.join(folder_path, 'functions'), exist_ok=True)
 
@@ -186,6 +186,5 @@ class Plugin(BaseModel):
             with open(os.path.join(folder_path, 'README.md'), 'w') as f:
                 f.write(readme_string)
 
-        if license_string is not None:
-            with open(os.path.join(folder_path, 'LICENSE'), 'w') as f:
-                f.write(license_string)
+        with open(os.path.join(folder_path, 'LICENSE'), 'w') as f:
+            f.write('To see the license for this package refer to package.yaml')

--- a/queenbee/recipe/recipe.py
+++ b/queenbee/recipe/recipe.py
@@ -273,7 +273,7 @@ class Recipe(BaseModel):
                 )
             )
 
-    def to_folder(self, folder_path: str, readme_string: str = None, license_string: str = None):
+    def to_folder(self, folder_path: str, readme_string: str = None):
         """Write a Recipe to a folder
 
         Note:
@@ -309,7 +309,6 @@ class Recipe(BaseModel):
 
         Keyword Arguments:
             readme_string {str} -- The README file string (default: {None})
-            license_string {str} -- The LICENSE file string (default: {None})
         """
 
         os.makedirs(os.path.join(folder_path, 'flow'), exist_ok=True)
@@ -330,9 +329,8 @@ class Recipe(BaseModel):
             with open(os.path.join(folder_path, 'README.md'), 'w') as f:
                 f.write(readme_string)
 
-        if license_string is not None:
-            with open(os.path.join(folder_path, 'LICENSE'), 'w') as f:
-                f.write(license_string)
+        with open(os.path.join(folder_path, 'LICENSE'), 'w') as f:
+            f.write('To see the license for this package refer to package.yaml')
 
     def write_dependencies(self, folder_path: str, config: Config = Config()):
         """Fetch dependencies manifests and write them to the `.dependencies` folder
@@ -372,8 +370,7 @@ class Recipe(BaseModel):
                 folder_path=os.path.join(
                     folder_path, '.dependencies',
                     dependency.dependency_kind, dependency.ref_name),
-                readme_string=package_version.readme,
-                license_string=package_version.license,
+                readme_string=package_version.readme
             )
 
 


### PR DESCRIPTION
This PR removes the license file and uses the license field in meta data instead as the single source of declaring a license for a plugin or a recipe.

Resolves #154
