### PR TITLE
add optional artifact

### DIFF
--- a/queenbee/io/common.py
+++ b/queenbee/io/common.py
@@ -100,6 +100,12 @@ class PathOutput(GenericOutput):
         'is executed.'
         )
 
+    required: bool = Field(
+        True,
+        description='A boolean to indicate if an artifact output is required. A False '
+        'value makes the artifact optional.'
+    )
+
     @property
     def referenced_values(self) -> Dict[str, List[str]]:
         """Get referenced variables if any.
@@ -109,6 +115,10 @@ class PathOutput(GenericOutput):
                 are lists contain referenced value string.
         """
         return self._referenced_values(['path'])
+
+    @property
+    def is_optional(self):
+        return not self.required
 
 
 class FromOutput(GenericOutput):

--- a/queenbee/io/inputs/alias.py
+++ b/queenbee/io/inputs/alias.py
@@ -7,6 +7,7 @@ the original input.
 """
 
 import os
+import warnings
 from typing import Dict, Union, List
 
 from pydantic import constr, Field, validator
@@ -300,6 +301,17 @@ class DAGFolderInputAlias(DAGGenericInputAlias):
         description='The default source for file if the value is not provided.'
     )
 
+    @validator('required', always=True)
+    def check_required(cls, v, values):
+        """Overwrite check_required fro artifacts to allow optional artifacts."""
+        default = values.get('default', None)
+        name = values.get('name', None)
+        if default is None and v is False:
+            warnings.warn(
+                f'{cls.__name__}.{name} -> set to optional input artifact.'
+            )
+        return v
+
     def validate_spec(self, value):
         """Validate an input value against specification.
 
@@ -316,6 +328,11 @@ class DAGFolderInputAlias(DAGGenericInputAlias):
     @property
     def is_artifact(self):
         return True
+
+    @property
+    def is_optional(self):
+        """A boolean that indicates if an artifact is optional."""
+        return self.default is None and self.required is False
 
 
 class DAGFileInputAlias(DAGFolderInputAlias):

--- a/queenbee/io/inputs/dag.py
+++ b/queenbee/io/inputs/dag.py
@@ -1,6 +1,7 @@
 """Queenbee input types for a DAG."""
 
 import os
+import warnings
 from typing import Dict, Union, List
 
 from pydantic import constr, Field, validator
@@ -266,6 +267,17 @@ class DAGFolderInput(DAGGenericInput):
         description='The default source for file if the value is not provided.'
     )
 
+    @validator('required', always=True)
+    def check_required(cls, v, values):
+        """Overwrite check_required fro artifacts to allow optional artifacts."""
+        default = values.get('default', None)
+        name = values.get('name', None)
+        if default is None and v is False:
+            warnings.warn(
+                f'{cls.__name__}.{name} -> set to optional input artifact.'
+            )
+        return v
+
     def validate_spec(self, value):
         """Validate an input value against specification.
 
@@ -282,6 +294,11 @@ class DAGFolderInput(DAGGenericInput):
     @property
     def is_artifact(self):
         return True
+
+    @property
+    def is_optional(self):
+        """A boolean that indicates if an artifact is optional."""
+        return self.default is None and self.required is False
 
 
 class DAGFileInput(DAGFolderInput):

--- a/queenbee/io/inputs/dag.py
+++ b/queenbee/io/inputs/dag.py
@@ -274,7 +274,8 @@ class DAGFolderInput(DAGGenericInput):
         name = values.get('name', None)
         if default is None and v is False:
             warnings.warn(
-                f'{cls.__name__}.{name} -> set to optional input artifact.'
+                f'{cls.__name__}.{name} has no default value and is not required. '
+                'Set to optional input artifact.'
             )
         return v
 

--- a/queenbee/io/outputs/alias.py
+++ b/queenbee/io/outputs/alias.py
@@ -59,7 +59,23 @@ class DAGLinkedOutputAlias(DAGGenericOutputAlias):
     type: constr(regex='^DAGLinkedOutputAlias$') = 'DAGLinkedOutputAlias'
 
 
-class DAGFileOutputAlias(DAGGenericOutputAlias):
+class _DAGArtifactOutputAlias(DAGGenericOutputAlias):
+    """Base class for DAG artifact output aliases.
+
+    This class add a required input. By default all artifact outputs are required.
+    """
+    required: bool = Field(
+        True,
+        description='A boolean to indicate if an artifact output is required. A False '
+        'value makes the artifact optional.'
+    )
+
+    @property
+    def is_optional(self):
+        return not self.required
+
+
+class DAGFileOutputAlias(_DAGArtifactOutputAlias):
     """DAG alias file output."""
     type: constr(regex='^DAGFileOutputAlias$') = 'DAGFileOutputAlias'
 
@@ -74,7 +90,7 @@ class DAGFileOutputAlias(DAGGenericOutputAlias):
         return True
 
 
-class DAGFolderOutputAlias(DAGGenericOutputAlias):
+class DAGFolderOutputAlias(_DAGArtifactOutputAlias):
     """DAG alias folder output."""
     type: constr(regex='^DAGFolderOutputAlias$') = 'DAGFolderOutputAlias'
 
@@ -89,7 +105,7 @@ class DAGFolderOutputAlias(DAGGenericOutputAlias):
         return True
 
 
-class DAGPathOutputAlias(DAGGenericOutputAlias):
+class DAGPathOutputAlias(_DAGArtifactOutputAlias):
     """DAG alias path output."""
     type: constr(regex='^DAGPathOutputAlias$') = 'DAGPathOutputAlias'
 

--- a/queenbee/io/outputs/dag.py
+++ b/queenbee/io/outputs/dag.py
@@ -29,7 +29,23 @@ class DAGGenericOutput(FromOutput):
         return [] if v is None else v
 
 
-class DAGFileOutput(DAGGenericOutput):
+class _DAGArtifactOutput(DAGGenericOutput):
+    """Base class for DAG artifact outputs.
+
+    This class add a required input. By default all artifact outputs are required.
+    """
+    required: bool = Field(
+        True,
+        description='A boolean to indicate if an artifact output is required. A False '
+        'value makes the artifact optional.'
+    )
+
+    @property
+    def is_optional(self):
+        return not self.required
+
+
+class DAGFileOutput(_DAGArtifactOutput):
     """DAG file output."""
     type: constr(regex='^DAGFileOutput$') = 'DAGFileOutput'
 
@@ -44,7 +60,7 @@ class DAGFileOutput(DAGGenericOutput):
         return True
 
 
-class DAGFolderOutput(DAGGenericOutput):
+class DAGFolderOutput(_DAGArtifactOutput):
     """DAG folder output."""
     type: constr(regex='^DAGFolderOutput$') = 'DAGFolderOutput'
 
@@ -59,7 +75,7 @@ class DAGFolderOutput(DAGGenericOutput):
         return True
 
 
-class DAGPathOutput(DAGGenericOutput):
+class DAGPathOutput(_DAGArtifactOutput):
     """DAG path output."""
     type: constr(regex='^DAGPathOutput$') = 'DAGPathOutput'
 

--- a/tests/assets/functions/valid/function.yaml
+++ b/tests/assets/functions/valid/function.yaml
@@ -6,6 +6,8 @@ inputs:
       description: desired sky horizontal irradiance
       required: true
     - name: sky-file
+      type: FunctionFileInput
+      path: file.sky
       required: true
 command: gensky -c -B "{{ inputs.desired-irradiance }}" > file.sky
 outputs:

--- a/tests/assets/functions/valid/function_optional_input.yaml
+++ b/tests/assets/functions/valid/function_optional_input.yaml
@@ -1,0 +1,36 @@
+type: Function
+name: split-grid
+description: Split the daylight sensor grid into multiple smaller files for parallel
+  simulation
+inputs:
+  - name: grid-name
+    type: FunctionStringInput
+    default: grid
+    description: Name of the grid
+  - name: sensor-count
+    type: FunctionIntegerInput
+    default: 250
+    description: Number of sensors per split grid
+  - name: input-grid-folder
+    type: FunctionFolderInput
+    description: The folder containing the grids to split # this is important for copying the files.
+    path: asset/grid
+    required: true
+  - name: bsdf-folder
+    type: FunctionFolderInput
+    description: An optional input that should only be copied if available.
+    path: asset/xml
+    required: False
+
+command: |
+  honeybee radiance grid split "asset/grid/{{inputs.grid-name}}.pts"
+  "{{inputs.sensor-count}}" --folder "output/temp/"
+  --log-file "output/temp/{{inputs.grid-name}}_grids.txt"
+
+outputs:
+  - name: grid-list
+    type: FunctionArrayOutput
+    path: "output/temp/{{inputs.grid-name}}_grids.txt"
+  - name: output-grids-folder
+    type: FunctionFolderOutput
+    path: output/temp/

--- a/tests/assets/functions/valid/function_optional_output.yaml
+++ b/tests/assets/functions/valid/function_optional_output.yaml
@@ -1,0 +1,33 @@
+type: Function
+name: split-grid
+description: Split the daylight sensor grid into multiple smaller files for parallel
+  simulation
+inputs:
+  - name: grid-name
+    type: FunctionStringInput
+    default: grid
+    description: Name of the grid
+  - name: sensor-count
+    type: FunctionIntegerInput
+    default: 250
+    description: Number of sensors per split grid
+  - name: input-grid-folder
+    type: FunctionFolderInput
+    description: The folder containing the grids to split # this is important for copying the files.
+    path: asset/grid
+    required: true
+command: |
+  honeybee radiance grid split "asset/grid/{{inputs.grid-name}}.pts"
+  "{{inputs.sensor-count}}" --folder "output/temp/"
+  --log-file "output/temp/{{inputs.grid-name}}_grids.txt"
+outputs:
+  - name: grid-list
+    type: FunctionArrayOutput
+    path: "output/temp/{{inputs.grid-name}}_grids.txt"
+  - name: output-grids-folder
+    type: FunctionFolderOutput
+    path: output/temp/
+  - name: optional-output
+    type: FunctionFolderOutput
+    path: output/temp/optional
+    required: False

--- a/tests/assets/recipes/valid/optional-input-output.yaml
+++ b/tests/assets/recipes/valid/optional-input-output.yaml
@@ -1,0 +1,46 @@
+type: Recipe
+
+metadata:
+  type: MetaData
+  name: minimal-recipe
+  tag: 0.2.1
+
+dependencies:
+- type: Dependency
+  kind: plugin
+  name: honeybee-radiance
+  tag: 1.2.3
+  source: https://example.com/test-repo
+
+flow:
+- name: main
+  type: DAG
+  inputs:
+  - name: folder-path
+    type: DAGStringInput
+    default: something
+  - name: input-file-optional
+    type: DAGFileInput
+    required: False
+  tasks:
+  - name: minimal-task
+    type: DAGTask
+    template: honeybee-radiance/10000-lux-sky
+    arguments:
+      - name: foo
+        type: TaskArgument
+        from:
+          type: ValueReference
+          value: test-value
+      - name: bar
+        type: TaskArgument
+        from:
+          type: ValueReference
+          value: test-value
+  outputs:
+    - name: optional-output
+      type: DAGFolderOutput
+      from:
+        type: FolderReference
+        path: path/to/file
+      required: False


### PR DESCRIPTION
This commit adds support for optional artifact inputs and outputs. This change will make it possible to support radiance recipes with BSDF materials.

@AntoineDao, I added an `is_optional` property to artifact input/outputs which can be used to update the extensions to support optional types.