### PR TITLE
fix(basemodel): allow extra fields in Queenbee objects

### DIFF
--- a/queenbee/base/basemodel.py
+++ b/queenbee/base/basemodel.py
@@ -165,6 +165,3 @@ class BaseModel(BaseModelNoType):
     @validator('annotations', always=True)
     def replace_none_value(cls, v):
         return {} if not v else v
-
-    class Config:
-        extra = Extra.forbid


### PR DESCRIPTION
Now that we use queenee DSL to write the recipes and  the schema is stable we can relax the check and allow additional fields.

This will make it possible to support non-breaking changes for schema on Pollination.