### PR TITLE
fix: resolve local dependency path on \*nix correctly

### DIFF
--- a/queenbee/config/repositories.py
+++ b/queenbee/config/repositories.py
@@ -19,7 +19,7 @@ class RepositoryReference(BaseModel):
 
     @validator('path')
     def remote_or_local(cls, v):
-        """Determine whether the path is local or remote (ie: http)"""
+        """Format local uri as needed (ie: file:///)"""
         return get_uri(v)
 
     def fetch(self, auth_header: Dict[str, str] = {}) -> 'RepositoryIndex':

--- a/queenbee/recipe/dependency.py
+++ b/queenbee/recipe/dependency.py
@@ -1,11 +1,11 @@
 """Queenbee dependency class."""
-import os
 from typing import Dict
 from enum import Enum
 from pydantic import Field, constr
 
+
 from ..base.basemodel import BaseModel
-from ..base.request import make_request, urljoin
+from ..base.request import make_request, urljoin, resolve_local_source
 
 
 class DependencyKind(str, Enum):
@@ -94,12 +94,8 @@ class Dependency(BaseModel):
         """
         from ..repository.index import RepositoryIndex
 
-        if self.source.startswith('file:///'):
-            rel_path = self.source.split('file:///')[1]
-
-            abs_path = os.path.join(os.getcwd(), rel_path, 'index.json')
-
-            url = f'file:///{abs_path}'
+        if self.source.startswith('file:'):
+            url = resolve_local_source(self.source) + '/index.json'
         else:
             url = urljoin(self.source, 'index.json')
 


### PR DESCRIPTION
This PR addresses the issue with resolving the local path as a uri. It took mixed usage of `os.path` and `pathlib.Path` to get it right on both Windows and Linux. Part of the issue was how in Windows and \*nix systems based on what the uri is pointing to the number of slashes after file:// can be 2 or 3! I was expecting it to always be 3 which would return `home/user/...` instead of `/home/user/...`. The first one is considered an absolute path and the second one is relative! That's the main reason that it was failing. I also took the opportunity to clean the code a little bit.

resolves #266
