### PR TITLE
style(optional artifact):  catch the cause for misleading warning

### DIFF
--- a/queenbee/base/basemodel.py
+++ b/queenbee/base/basemodel.py
@@ -5,7 +5,7 @@ from typing import List, Dict
 
 import yaml
 from pydantic import BaseModel as PydanticBaseModel
-from pydantic import validator, Field, constr, Extra
+from pydantic import validator, Field, constr
 
 from .parser import parse_file
 from .variable import get_ref_variable

--- a/queenbee/io/inputs/dag.py
+++ b/queenbee/io/inputs/dag.py
@@ -270,7 +270,9 @@ class DAGFolderInput(DAGGenericInput):
     @validator('required', always=True)
     def check_required(cls, v, values):
         """Overwrite check_required fro artifacts to allow optional artifacts."""
-        default = values.get('default', None)
+        if 'default' not in values:
+            return v
+        default = values.get('default')
         name = values.get('name', None)
         if default is None and v is False:
             warnings.warn(


### PR DESCRIPTION
This changes ensures the warning for optional artifacts will only be printed in valid cases.