### PR TITLE
fix(deps): revert to pydantic 1.7.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pydantic==1.8
+pydantic==1.7.3
 PyYAML==5.4.1
 jsonschema==3.2.0

--- a/tests/base/hash_test.py
+++ b/tests/base/hash_test.py
@@ -1,0 +1,18 @@
+import pytest
+
+from ._base import BaseTestClass
+
+@pytest.mark.hash
+class BaseHashTest(BaseTestClass):
+
+    def pytest_generate_tests(self, metafunc):
+        
+        object_instances = self.fixture_instances('valid')
+
+        if "instance" in metafunc.fixturenames:
+            metafunc.parametrize("instance", object_instances)
+
+    def test_generates_hash(self, instance):
+        """Test to check for bug introduced in Pydantic 1.8"""
+        
+        assert instance.__hash__ is not None

--- a/tests/operator/operator_test.py
+++ b/tests/operator/operator_test.py
@@ -2,6 +2,7 @@ import yaml
 from tests.base.io_test import BaseIOTest
 from tests.base.value_error import BaseValueErrorTest
 from tests.base.folder_test import BaseFolderTest
+from tests.base.hash_test import BaseHashTest
 
 from queenbee.plugin import Plugin
 
@@ -23,6 +24,13 @@ class TestValueError(BaseValueErrorTest):
 
 
 class TestFolder(BaseFolderTest):
+
+    klass = Plugin
+
+    asset_folder = ASSET_FOLDER
+
+
+class TestHash(BaseHashTest):
 
     klass = Plugin
 

--- a/tests/recipe/recipe_test.py
+++ b/tests/recipe/recipe_test.py
@@ -1,6 +1,7 @@
 from tests.base.io_test import BaseIOTest
 from tests.base.value_error import BaseValueErrorTest
 from tests.base.folder_test import BaseFolderTest
+from tests.base.hash_test import BaseHashTest
 
 from queenbee.recipe import Recipe
 
@@ -22,6 +23,13 @@ class TestValueError(BaseValueErrorTest):
 
 
 class TestFolder(BaseFolderTest):
+
+    klass = Recipe
+
+    asset_folder = ASSET_FOLDER
+
+
+class TestHash(BaseHashTest):
 
     klass = Recipe
 


### PR DESCRIPTION
Pydantic 1.8 breaks the hashing functions somehow. I think we should move to 1.8 once they have
fixed that bug. I am also not sure how to go about testing this bug reliably to avoid future
dependencies update that cause a similar bug...

#280