### PR TITLE
fix(status): enumerate job/run/step status strings

### DIFF
--- a/queenbee/job/job.py
+++ b/queenbee/job/job.py
@@ -55,6 +55,8 @@ class JobStatusEnum(str, Enum):
     running = 'Running'
     # The job has failed to schedule runs
     failed = 'Failed'
+    # The job has been cancelled by a user
+    cancelled = 'Cancelled'
     # All runs have either succeeded or failed
     completed = 'Completed'
     # Could not determine the status of the job

--- a/queenbee/job/job.py
+++ b/queenbee/job/job.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Dict, List, Generator
 from datetime import datetime
 
@@ -5,7 +6,6 @@ from pydantic import Field, constr
 
 from ..base.basemodel import BaseModel
 from ..io.inputs.job import JobArguments
-from .status import BaseStatus
 
 class Job(BaseModel):
     """Queenbee Job.
@@ -44,6 +44,23 @@ class Job(BaseModel):
     )
 
 
+class JobStatusEnum(str, Enum):
+    """Enumaration of allowable status strings"""
+
+    # The job has been created
+    created = 'Created'
+    # The job folder is being prepared for execution and runs are being scheduled
+    pre_processing = 'Pre-Processing'
+    # Runs have been scheduled
+    running = 'Running'
+    # The job has failed to schedule runs
+    failed = 'Failed'
+    # All runs have either succeeded or failed
+    completed = 'Completed'
+    # Could not determine the status of the job
+    unknown = 'Unknown'
+
+
 class JobStatus(BaseModel):
     """Parametric Job Status."""
 
@@ -56,20 +73,19 @@ class JobStatus(BaseModel):
         description='The ID of the individual job.'
     )
 
-    status: str = Field(
-        ...,
-        description='The status of this task. Can be "Running", "Succeeded", "Failed" '
-        'or "Error"'
+    status: JobStatusEnum = Field(
+        JobStatusEnum.unknown,
+        description='The status of this job.'
     )
 
     message: str = Field(
         None,
-        description='Any message produced by the task. Usually error/debugging hints.'
+        description='Any message produced by the job. Usually error/debugging hints.'
     )
 
     started_at: datetime = Field(
         ...,
-        description='The time at which the task was started'
+        description='The time at which the job was started'
     )
 
     finished_at: datetime = Field(

--- a/queenbee/job/run.py
+++ b/queenbee/job/run.py
@@ -14,6 +14,23 @@ from ..io.outputs.step import StepOutputs
 from .status import BaseStatus
 
 
+class StepStatusEnum(str, Enum):
+    """Enumaration of allowable status strings"""
+
+    # The step has been scheduled for execution
+    scheduled = 'Scheduled'
+    # The step is running
+    running = 'Running'
+    # The step has failed
+    failed = 'Failed'
+    # The step has finished succesfully
+    succeeded = 'Succeeded'
+    # The step has been skipped 
+    skipped = 'Skipped'
+    # Could not determine the status of the step
+    unknown = 'Unknown'
+
+
 class StatusType(str, Enum):
     """Type enum for status type."""
     Function = 'Function'
@@ -39,6 +56,11 @@ class StepStatus(BaseStatus):
         description='A human readable name for the step. Usually defined by the '
         'DAG task name but can be extended if the step is part of a loop for example. '
         'This name is unique within the boundary of the DAG/Job that generated it.'
+    )
+    
+    status: StepStatusEnum = Field(
+        StepStatusEnum.unknown,
+        description='The status of this step.'
     )
 
     status_type: StatusType = Field(
@@ -87,6 +109,25 @@ class StepStatus(BaseStatus):
     )
 
 
+class RunStatusEnum(str, Enum):
+    """Enumaration of allowable status strings"""
+    
+    # The run has been created
+    created = 'Created'
+    # The run has been scheduled for execution
+    scheduled = 'Scheduled'
+    # The run is being executed
+    running = 'Running'
+    # The run is being post-processed (status and folder cleanup)
+    post_processing = 'Post-Processing'
+    # The run has failed
+    failed = 'Failed'
+    # The run has completed succesfully
+    succeeded = 'Succeeded'
+    # Could not determine the status of the run
+    unknown = 'Unknown'
+
+
 class RunStatus(BaseStatus):
     """Job Status."""
     api_version: constr(regex='^v1beta1$') = Field('v1beta1', readOnly=True)
@@ -100,12 +141,17 @@ class RunStatus(BaseStatus):
 
     job_id: str = Field(
         ...,
-        description='The ID of the job that generated this run'
+        description='The ID of the job that generated this run.'
     )
 
     entrypoint: str = Field(
         None,
         description='The ID of the first step in the run.'
+    )
+
+    status: RunStatusEnum = Field(
+        RunStatusEnum.unknown,
+        description='The status of this run.'
     )
 
     steps: Dict[str, StepStatus] = {}

--- a/queenbee/job/run.py
+++ b/queenbee/job/run.py
@@ -122,6 +122,8 @@ class RunStatusEnum(str, Enum):
     post_processing = 'Post-Processing'
     # The run has failed
     failed = 'Failed'
+    # The run has been cancelled by a user
+    cancelled = 'Cancelled'
     # The run has completed succesfully
     succeeded = 'Succeeded'
     # Could not determine the status of the run

--- a/queenbee/job/status.py
+++ b/queenbee/job/status.py
@@ -11,12 +11,6 @@ class BaseStatus(IOBase):
     """Base Status model"""
     type: constr(regex='^BaseStatus$') = 'BaseStatus'
 
-    status: str = Field(
-        ...,
-        description='The status of this task. Can be "Running", "Succeeded", "Failed" '
-        'or "Error"'
-    )
-
     message: str = Field(
         None,
         description='Any message produced by the task. Usually error/debugging hints.'


### PR DESCRIPTION
This makes it clearer what status strings to expect and helps generate more robust SDK clients.