### PR TITLE
feat(packages): Use AnyUrl type

### DIFF
--- a/queenbee/base/metadata.py
+++ b/queenbee/base/metadata.py
@@ -71,17 +71,17 @@ class MetaData(BaseModel):
         description='A list of maintainers for the package'
     )
 
-    home: str = Field(
+    home: AnyUrl = Field(
         None,
         description='The URL of this package\'s home page'
     )
 
-    sources: List[str] = Field(
+    sources: List[AnyUrl] = Field(
         None,
         description='A list of URLs to source code for this project'
     )
 
-    icon: str = Field(
+    icon: AnyUrl = Field(
         None,
         description='A URL to an SVG or PNG image to be used as an icon'
     )

--- a/queenbee/plugin/plugin.py
+++ b/queenbee/plugin/plugin.py
@@ -3,7 +3,7 @@ import json
 import os
 import yaml
 from typing import List
-from pydantic import Field, validator, constr
+from pydantic import Field, validator, constr, AnyUrl
 
 from ..base.basemodel import BaseModel
 from ..base.metadata import MetaData
@@ -20,7 +20,7 @@ class DockerConfig(BaseModel):
         description='Docker image name. Must include tag.'
     )
 
-    registry: str = Field(
+    registry: AnyUrl = Field(
         None,
         description='The container registry URLs that this container should be pulled'
         ' from. Will default to Dockerhub if none is specified.'

--- a/queenbee/recipe/dependency.py
+++ b/queenbee/recipe/dependency.py
@@ -1,8 +1,7 @@
 """Queenbee dependency class."""
 from typing import Dict
 from enum import Enum
-from pydantic import Field, constr
-
+from pydantic import Field, constr, AnyUrl
 
 from ..base.basemodel import BaseModel
 from ..base.request import make_request, urljoin, resolve_local_source
@@ -49,7 +48,7 @@ class Dependency(BaseModel):
         description='Tag of the resource.'
     )
 
-    source: str = Field(
+    source: AnyUrl = Field(
         ...,
         description='URL to a repository where this resource can be found.',
         examples=[

--- a/queenbee/recipe/recipe.py
+++ b/queenbee/recipe/recipe.py
@@ -9,7 +9,7 @@ import json
 from typing import List, Union, Dict
 
 import yaml
-from pydantic import Field, validator, root_validator, constr
+from pydantic import Field, validator, root_validator, constr, AnyUrl
 
 from ..base.basemodel import BaseModel
 from ..base.metadata import MetaData
@@ -696,7 +696,7 @@ class RecipeInterface(BaseModel):
         description='Recipe metadata information.'
     )
 
-    source: str = Field(
+    source: AnyUrl = Field(
         None,
         description='A URL to the source this recipe from a registry.'
     )


### PR DESCRIPTION
I noticed while making search filters for packages that there are several fields that are described as URLs but don't use the `pydantic.AnyUrl` type. Though, maybe this was intentional. 