### PR TITLE
Validate run arguments

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.166.1/containers/python-3/.devcontainer/base.Dockerfile
+
+# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
+ARG VARIANT="3"
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+COPY . .
+RUN pip install -r requirements.txt -r dev-requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,3 +16,5 @@ click-plugins==1.1.1
 importlib-metadata==4.4.0
 wheel==0.36.2
 setuptools==57.0.0
+pylama
+autopep8

--- a/queenbee/job/job.py
+++ b/queenbee/job/job.py
@@ -43,6 +43,16 @@ class Job(BaseModel):
         ' only and will not be used in the execution of the job.'
     )
 
+    @validator('arguments', each_item=True)
+    def check_duplicate_names(cls, v):
+        argument_names = []
+        for arg in v:
+            if arg.name in argument_names:
+                raise ValueError(f'duplicate argument name {arg.name}')
+            argument_names.append(arg.name)
+
+        return v
+
 
 class JobStatusEnum(str, Enum):
     """Enumaration of allowable status strings"""

--- a/queenbee/job/job.py
+++ b/queenbee/job/job.py
@@ -57,6 +57,27 @@ class Job(BaseModel):
 
         return v
 
+    def populate_default_arguments(self, inputs: List[DAGInputs]):
+        for recipe_input in inputs:
+            for combination in self.arguments:
+                found_argument = False
+                for argument in combination:
+                    if argument.name == recipe_input.name:
+                        found_argument = True
+
+                if not found_argument and not recipe_input.required:
+                    if recipe_input.is_artifact:
+                        argument = JobPathArgument(
+                            name=recipe_input.name,
+                            source=recipe_input.default,
+                        )
+                    else:
+                        argument = JobArgument(
+                            name=recipe_input.name,
+                            value=recipe_input.default,
+                        )
+                    combination.append(argument)
+
     def validate_arguments(self, inputs: List[DAGInputs]):
         errors = []
         for i, arg in enumerate(self.arguments):
@@ -180,8 +201,7 @@ class JobStatus(BaseModel):
         description='The count of runs that have failed'
     )
 
-    runs_cancelled: int =Field(
+    runs_cancelled: int = Field(
         0,
         description='The count of runs that have been cancelled'
     )
-

--- a/tests/job/job_test.py
+++ b/tests/job/job_test.py
@@ -1,6 +1,60 @@
+from typing import List
+
 import pytest
 from pydantic.main import ValidationError
+from queenbee.io.artifact_source import HTTP
+from queenbee.io.inputs.dag import DAGInputs, DAGPathInput, DAGStringInput
 from queenbee.job import Job
+
+
+@pytest.fixture
+def optional_parameter_input():
+    return DAGStringInput(
+        name='optional-parameter-input',
+        required=False,
+        default='some-default-value'
+    )
+
+
+@pytest.fixture
+def required_parameter_input():
+    return DAGStringInput(
+        name='required-parameter-input',
+        required=True,
+    )
+
+
+@pytest.fixture
+def optional_artifact_input():
+    return DAGPathInput(
+        name='optional-artifact-input',
+        required=False,
+        default=HTTP(url='https://some.url.com/path/to/artifact')
+    )
+
+
+@pytest.fixture
+def required_artifact_input():
+    return DAGPathInput(
+        name='required-artifact-input',
+        required=True,
+    )
+
+
+@pytest.fixture
+def required_inputs(required_parameter_input, required_artifact_input):
+    return [required_parameter_input, required_artifact_input]
+
+
+@pytest.fixture
+def optional_inputs(optional_parameter_input, optional_artifact_input):
+    return [optional_parameter_input, optional_artifact_input]
+
+
+@pytest.fixture
+def all_inputs(required_inputs, optional_inputs):
+    return required_inputs + optional_inputs
+
 
 def test_duplicated_job_arguments():
     with pytest.raises(ValidationError) as validation_err:
@@ -36,3 +90,147 @@ def test_duplicated_job_arguments():
         'msg': 'duplicate argument name sensor-grid-count',
         'type': 'value_error'
     }]
+
+
+def test_valid_job_arguments(all_inputs: List[DAGInputs]):
+    job: Job = Job.parse_obj({
+        'source': 'https://example.com/registries/recipe/daylight-factor/latest',
+        'arguments': [[
+            {
+                'type': 'JobArgument',
+                'name': 'required-parameter-input',
+                'value': 'some-string'
+            },
+            {
+                'type': 'JobArgument',
+                'name': 'optional-parameter-input',
+                'value': 'some-string'
+            },
+            {
+                'type': 'JobPathArgument',
+                'name': 'required-artifact-input',
+                'source': {
+                    'type': 'ProjectFolder',
+                    'path': 'some/path'
+                }
+            },
+            {
+                'type': 'JobPathArgument',
+                'name': 'optional-artifact-input',
+                'source': {
+                    'type': 'ProjectFolder',
+                    'path': 'some/path'
+                }
+            },
+        ]]
+    })
+
+    job.validate_arguments(all_inputs)
+
+
+def test_required_job_arguments_missing(all_inputs: List[DAGInputs]):
+    job: Job = Job.parse_obj({
+        'source': 'https://example.com/registries/recipe/daylight-factor/latest',
+        'arguments': [[
+            {
+                'type': 'JobPathArgument',
+                'name': 'input-grid',
+                'source': {
+                    'type': 'ProjectFolder',
+                    'path': 'some/path'
+                }
+            },
+            {
+                'type': 'JobPathArgument',
+                'name': 'model_hbjson',
+                'source': {
+                    'type': 'ProjectFolder',
+                    'path': 'some/path'
+                }
+            }
+        ], [
+            {
+                'type': 'JobPathArgument',
+                'name': 'required-artifact-input',
+                'source': {
+                    'type': 'ProjectFolder',
+                    'path': 'some/path'
+                }
+            },
+        ]]
+    })
+
+    with pytest.raises(ValidationError) as validation_err:
+        job.validate_arguments(all_inputs)
+
+    assert validation_err.value.errors() == [
+        {
+            'loc': ('arguments', 0),
+            'msg': 'missing required argument required-parameter-input',
+            'type': 'value_error'
+        }, {
+            'loc': ('arguments', 0),
+            'msg': 'missing required argument required-artifact-input',
+            'type': 'value_error'
+        }, {
+            'loc': ('arguments', 1),
+            'msg': 'missing required argument required-parameter-input',
+            'type': 'value_error'
+        }
+    ]
+
+
+def test_invalid_job_arguments_type(all_inputs: List[DAGInputs]):
+    job: Job = Job.parse_obj({
+        'source': 'https://example.com/registries/recipe/daylight-factor/latest',
+        'arguments': [[
+            {
+                'type': 'JobArgument',
+                'name': 'required-parameter-input',
+                'value': 'some-string'
+            },
+            {
+                'type': 'JobPathArgument',
+                'name': 'optional-parameter-input',
+                'source': {
+                    'type': 'ProjectFolder',
+                    'path': 'some/path'
+                }
+            },
+            {
+                'type': 'JobPathArgument',
+                'name': 'required-artifact-input',
+                'source': {
+                    'type': 'ProjectFolder',
+                    'path': 'some/path'
+                }
+            },
+        ], [
+            {
+                'type': 'JobArgument',
+                'name': 'required-parameter-input',
+                'value': 'some-string'
+            },
+            {
+                'type': 'JobArgument',
+                'name': 'required-artifact-input',
+                'value': 'some-string'
+            },
+        ]]
+    })
+
+    with pytest.raises(ValidationError) as validation_err:
+        job.validate_arguments(all_inputs)
+
+    assert validation_err.value.errors() == [
+        {
+            'loc': ('arguments', 0),
+            'msg': 'invalid argument type for optional-parameter-input, should be "JobArgument"',
+            'type': 'value_error'
+        },
+        {
+            'loc': ('arguments', 1),
+            'msg': 'invalid argument type for required-artifact-input, should be "JobPathArgument"',
+            'type': 'value_error'
+        },
+    ]

--- a/tests/job/job_test.py
+++ b/tests/job/job_test.py
@@ -1,0 +1,38 @@
+import pytest
+from pydantic.main import ValidationError
+from queenbee.job import Job
+
+def test_duplicated_job_arguments():
+    with pytest.raises(ValidationError) as validation_err:
+        Job.parse_obj({
+            'source': 'https://example.com/registries/recipe/daylight-factor/latest',
+            'arguments': [[
+                {
+                    'type': 'JobArgument',
+                    'name': 'sensor-grid-count',
+                    'value': 200
+                },
+                {
+                    'type': 'JobPathArgument',
+                    'name': 'sensor-grid-count',
+                    'source': {
+                        'type': 'ProjectFolder',
+                        'path': 'some/path'
+                    }
+                },
+                {
+                    'type': 'JobPathArgument',
+                    'name': 'model_hbjson',
+                    'source': {
+                        'type': 'ProjectFolder',
+                        'path': 'some/path'
+                    }
+                }
+            ]]
+        })
+
+    assert validation_err.value.errors() == [{
+        'loc': ('arguments', 0),
+        'msg': 'duplicate argument name sensor-grid-count',
+        'type': 'value_error'
+    }]

--- a/tests/job/job_test.py
+++ b/tests/job/job_test.py
@@ -234,3 +234,62 @@ def test_invalid_job_arguments_type(all_inputs: List[DAGInputs]):
             'type': 'value_error'
         },
     ]
+
+
+def test_populate_optional_arguments(optional_inputs: List[DAGInputs]):
+    job: Job = Job.parse_obj({
+        'source': 'https://example.com/registries/recipe/daylight-factor/latest',
+        'arguments': [[
+            {
+                'type': 'JobArgument',
+                'name': 'optional-parameter-input',
+                'value': 'some-string'
+            }
+        ], [
+            {
+                'type': 'JobPathArgument',
+                'name': 'optional-artifact-input',
+                'source': {
+                    'type': 'ProjectFolder',
+                    'path': 'some/path'
+                }
+            }
+        ]]
+    })
+
+    job.populate_default_arguments(optional_inputs)
+
+    expected_job = Job.parse_obj({
+        'source': 'https://example.com/registries/recipe/daylight-factor/latest',
+        'arguments': [[
+            {
+                'type': 'JobArgument',
+                'name': 'optional-parameter-input',
+                'value': 'some-string'
+            },
+            {
+                'type': 'JobPathArgument',
+                'name': 'optional-artifact-input',
+                'source': {
+                    'type': 'HTTP',
+                    'url': 'https://some.url.com/path/to/artifact'
+                }
+            }
+        ], [
+            {
+                'type': 'JobPathArgument',
+                'name': 'optional-artifact-input',
+                'source': {
+                    'type': 'ProjectFolder',
+                    'path': 'some/path'
+                }
+            },
+            {
+                'type': 'JobArgument',
+                'name': 'optional-parameter-input',
+                'value': 'some-default-value'
+            },
+        ]]
+    })
+
+    assert job == expected_job


### PR DESCRIPTION
This PR addresses underlying issues with Job Argument validation.

- [x] duplicate argument name check
- [x] missing recipe input argument
- [x] populate job arguments with default recipe values