### PR TITLE
fix(deps): bump pydantci to 1.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pydantic==1.8.2
+pydantic==1.9.0
 PyYAML==5.4.1
 jsonschema==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pydantic==1.9.0
+pydantic>=1.8.2
 PyYAML==5.4.1
 jsonschema==3.2.0


### PR DESCRIPTION
LBT libraries are moved to 1.9.0 and without updating the dependency here we will have conflict issues for local runs.