### PR TITLE
fix(status): add support for Container status type

### DIFF
--- a/queenbee/job/run.py
+++ b/queenbee/job/run.py
@@ -39,6 +39,8 @@ class StatusType(str, Enum):
 
     Loop = 'Loop'
 
+    Container = 'Container'
+
     Unknown = 'Unknown'
 
 


### PR DESCRIPTION
This type is mainly used by Argo containerset.