### PR TITLE
ci(pypi): use PyPi token instead of username and password

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,8 +60,8 @@ jobs:
           echo "::set-output name=tag::$nextRelease"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          PYPI_PASSWORD: ${{ secrets.POLLINATION_PYPI_PASSWORD }}
+          PYPI_USERNAME: ${{ secrets.POLLINATION_PYPI_USERNAME }}
     outputs:
       tag: ${{ steps.new_release.outputs.tag }}
 


### PR DESCRIPTION
Apparently username and password is no longer a supported deployment method: https://github.com/pollination/queenbee/actions/runs/9054289912/job/24873984153#step:8:3423

@mostaphaRoudsari , could I get you to add a new PyPi API Token scoped to this repository and name is `PYPI_TOKEN`? Here are the instructions to create the token: https://pypi.org/help/#apitoken

I suspect this is created and managed by the ladybugbot account. This is part of some upgrades I am making that will allow me to upgrade pollination server to python 3.12.